### PR TITLE
Include error details in /logs endpoint

### DIFF
--- a/server/deep_god.py
+++ b/server/deep_god.py
@@ -192,6 +192,7 @@ DEEP_ORES = {
 class DeepGod:
     def __init__(self):
         self.conversation_history: list[dict] = []
+        self.last_error: str | None = None
 
     def should_act(self, event_summary: str | None, player_status: dict | None,
                    kind_god_action_count: int, praying_player: str | None = None) -> bool:
@@ -286,8 +287,9 @@ class DeepGod:
                 tool_choice="auto",
                 temperature=0.7,  # less creative, more consistent
             )
-        except Exception:
+        except Exception as exc:
             logger.exception("Deep God LLM call failed")
+            self.last_error = f"{type(exc).__name__}: {exc}"
             self.conversation_history.pop()
             return None
 

--- a/server/herald_god.py
+++ b/server/herald_god.py
@@ -104,6 +104,7 @@ class HeraldGod:
     def __init__(self):
         self.conversation_history: list[dict] = []
         self._last_spoke: float = 0
+        self.last_error: str | None = None
 
     def should_act(self, event_summary: str | None) -> bool:
         """Determine whether the Herald should speak this cycle.
@@ -145,8 +146,9 @@ class HeraldGod:
                 tool_choice="auto",
                 temperature=0.9,
             )
-        except Exception:
+        except Exception as exc:
             logger.exception("Herald LLM call failed")
+            self.last_error = f"{type(exc).__name__}: {exc}"
             self.conversation_history.pop()
             return None
 

--- a/server/kind_god.py
+++ b/server/kind_god.py
@@ -423,6 +423,7 @@ class KindGod:
         self.conversation_history: list[dict] = []
         self.action_count: int = 0  # tracks interventions for Deep God trigger
         self.memory = KindGodMemory(MEMORY_FILE)
+        self.last_error: str | None = None
 
     async def think(self, event_summary: str) -> list[dict]:
         """Process events and return Minecraft commands."""
@@ -449,8 +450,9 @@ class KindGod:
                     tool_choice="auto",
                     temperature=0.9,
                 )
-            except Exception:
+            except Exception as exc:
                 logger.exception("Kind God LLM call failed")
+                self.last_error = f"{type(exc).__name__}: {exc}"
                 if turn == 0:
                     self.conversation_history.pop()
                     return None  # signal failure on first call

--- a/server/main.py
+++ b/server/main.py
@@ -313,7 +313,7 @@ async def _god_tick_inner(praying_player: str | None = None):
             # LLM call failed — notify players
             command_queue.extend(_god_failure_commands("deep", target=intercept_target))
             _recent_logs.append({"time": tick_ts, "god": "deep", "action": "error",
-                                 "prayer": praying_player})
+                                 "error": deep_god.last_error, "prayer": praying_player})
             commands = []
 
         # Notify the Kind God that the Other acted
@@ -328,7 +328,7 @@ async def _god_tick_inner(praying_player: str | None = None):
             # LLM call failed — notify players
             command_queue.extend(_god_failure_commands("kind", target=intercept_target))
             _recent_logs.append({"time": tick_ts, "god": "kind", "action": "error",
-                                 "prayer": praying_player})
+                                 "error": kind_god.last_error, "prayer": praying_player})
             commands = []
 
     if commands:
@@ -354,7 +354,8 @@ async def _god_tick_inner(praying_player: str | None = None):
         if herald_commands is None:
             # LLM call failed — notify players
             command_queue.extend(_god_failure_commands("herald"))
-            _recent_logs.append({"time": tick_ts, "god": "herald", "action": "error"})
+            _recent_logs.append({"time": tick_ts, "god": "herald", "action": "error",
+                                 "error": herald_god.last_error})
         elif herald_commands:
             command_queue.extend(herald_commands)
             logger.info(f"Queued {len(herald_commands)} Herald commands")


### PR DESCRIPTION
## Summary

- When a god's LLM call fails, the `/logs` endpoint now includes the exception type and message in the log entry (e.g. `"error": "APITimeoutError: Request timed out."`)
- Previously error entries only had `{"action": "error"}` with no diagnostic info, requiring journalctl to investigate
- Each god class stores `self.last_error` on failure, which `main.py` reads into the structured log

## Test plan

- [ ] Restart backend with the new code
- [ ] Trigger an LLM error (e.g. temporarily break the API key or endpoint)
- [ ] Verify `curl http://localhost:8000/logs` shows the `"error"` field with exception details
- [ ] Verify normal (non-error) log entries are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)