### PR TITLE
Add pydantic validation for tool calls and whitelist player validation

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -57,3 +57,6 @@ DIG_MAX_STEPS = 64
 # Dig God memory
 DIG_MEMORY_FILE = MEMORY_DIR / "dig_god_memory.json"
 DIG_MEMORY_MAX_ENTRIES = 15
+
+# Player whitelist (Paper server)
+WHITELIST_FILE = _project_root / "paper" / "whitelist.json"

--- a/server/main.py
+++ b/server/main.py
@@ -765,6 +765,9 @@ async def _process_divine_request(request: DivineRequest):
                                f"(attempt {request.attempts}/{MAX_ATTEMPTS})")
                 return
 
+            if kind_god.last_memory:
+                _log_activity(f"Kind God reflects: {kind_god.last_memory}")
+
     if commands:
         command_queue.extend(commands)
         cmd_summaries = []
@@ -943,6 +946,9 @@ async def _god_tick_inner():
             _recent_logs.append({"time": tick_ts, "god": "kind", "action": "tick_error",
                                  "error": kind_god.last_error})
             commands = []
+
+        if kind_god.last_memory:
+            _log_activity(f"Kind God reflects: {kind_god.last_memory}")
 
     if commands:
         command_queue.extend(commands)


### PR DESCRIPTION
## Summary

- Adds 14 pydantic models to validate all tool call arguments in `commands.py`, with LLM-friendly error messages that guide self-correction
- Validates player names against the server whitelist (`paper/whitelist.json`) with case-insensitive matching and mtime-based caching
- Adds a memory reflection turn to the Kind God (two-turn pattern matching Dig God)
- Numeric values (count, duration, amplifier) are clamped via before-validators instead of hard-rejected, avoiding wasted API round-trips
- 7 new tests added, all 335 tests passing

## Test plan

- [x] All 335 tests pass (`pytest server/tests/ -v`)
- [x] Backend restarted and tested in-game
- [x] Observed whitelist-based username correction working in production logs
- [x] Kind God memory reflections appearing in logs after actions

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)